### PR TITLE
Fix addon voting through api

### DIFF
--- a/client-user.php
+++ b/client-user.php
@@ -25,6 +25,7 @@ require_once(INCLUDE_DIR . 'ClientSession.class.php');
 require_once(INCLUDE_DIR . 'Server.class.php');
 require_once(INCLUDE_DIR . 'User.class.php');
 require_once(INCLUDE_DIR . 'XMLOutput.class.php');
+require_once(INCLUDE_DIR . 'Ratings.class.php');
 
 $action = isset($_POST['action']) ? $_POST['action'] : "";
 $output = new XMLOutput();
@@ -222,10 +223,9 @@ try {
                 $addonid = isset($_POST['addonid']) ? $_POST['addonid'] : "";
                 $rating = isset($_POST['rating']) ? $_POST['rating'] : -1.0;
                 $rating_object = new Ratings($addonid, false);
-                $new_vote = $rating_object->setUserVote($rating, ClientSession::get($token, $userid));
+                $rating_object->setUserVote($rating, ClientSession::get($token, $userid));
                 $output->startElement('set-addon-vote');
                 $output->writeAttribute('success','yes');
-                $output->writeAttribute('new-vote', ($new_vote ? 'yes' : 'no'));
                 $output->writeAttribute('new-average', $rating_object->getAvgRating());
                 $output->writeAttribute('new-number', $rating_object->getNumRatings());
                 $output->writeAttribute('addon-id', $rating_object->getAddonId());

--- a/include/Addon.class.php
+++ b/include/Addon.class.php
@@ -282,7 +282,7 @@ class Addon {
                     'SELECT `id`
                      FROM `'.DB_PREFIX.'addons`
                      WHERE `id` = :addon_id',
-                    DBConnection::ROW_COUND,
+                    DBConnection::ROW_COUNT,
                     array(':addon_id' => Addon::cleanId($addon_id)));
             return ($num === 1);
         } catch (DBException $e) {

--- a/include/Ratings.class.php
+++ b/include/Ratings.class.php
@@ -249,13 +249,13 @@ class Ratings {
                 _('Please contact a website administrator if this problem persists.'));
         
         try{
-            $count = DBConnection::get()->query
+            DBConnection::get()->query
             (
                 "INSERT INTO `" . DB_PREFIX ."votes`
                 (`user_id`, `addon_id`, `vote`)
                 VALUES (:user_id, :addon_id, :rating)
                 ON DUPLICATE KEY UPDATE vote = :rating",
-                DBConnection::ROW_COUNT,
+                DBConnection::NOTHING,
                 array
                 (
                     ':addon_id'     => (string) $this->addon_id,
@@ -263,12 +263,6 @@ class Ratings {
                     ':rating'       => (float) $vote
                 )
             );
-            if ($count === 1)
-                $new_vote = true;
-            elseif ($count === 2)
-                $new_vote = false;
-            else
-                throw new DBException();
         }catch (DBException $e){
             throw new RatingsException(
                 _('An unexpected error occured while performing your vote.') . ' ' .
@@ -283,9 +277,7 @@ class Ratings {
         // Regenerate the XML files after voting
         writeAssetXML();
         writeNewsXML();	
-        
-        return $new_vote;
-        }
+    }
         
     /**
      * Gets the percentage of total possible rating value


### PR DESCRIPTION
There is no good way to tell if you insert or update a row using the
rowCount pdo operation. If your vote didn't change, this would return 0
and thus throw an exception. Any other case should return 1, assuming
the database primary key is correctly set.
