### PR TITLE
Fixed double site_root in header.tpl

### DIFF
--- a/include/StkTemplate.class.php
+++ b/include/StkTemplate.class.php
@@ -47,7 +47,7 @@ class StkTemplate extends Template {
 
         // Fill script tags
         $script_inline = array(
-            array('content' => "var siteRoot='http://localhost/stk-web/';")
+            array('content' => "var siteRoot='" . SITE_ROOT . "';")
         );
         $this->smarty->assign('script_inline', $script_inline);
         $script_includes = array(
@@ -56,7 +56,7 @@ class StkTemplate extends Template {
             array('src' => SITE_ROOT . 'js/script.js')
         );
         $this->smarty->assign('script_includes', $script_includes);
-        $this->smarty->assign('site_root', SITE_ROOT);
+
     }
     
     private function setupTopMenu() {

--- a/tpl/default/header.tpl
+++ b/tpl/default/header.tpl
@@ -12,7 +12,7 @@
 	{foreach $script_includes as $script}
 	<script type="{$script.type|default:'text/javascript'}" src="{$script.src}"></script>
 	{/foreach}
-    <script type="text/javascript">var siteRoot='{$site_root}';</script>
+
 	<link rel="stylesheet" media="screen" href="{#css_screen#}" />
 	<link rel="stylesheet" media="print" href="{#css_print#}" />
     </head>


### PR DESCRIPTION
When going through the code of the templates I found a double definition for an inline script that defined the siteRoot. One was defined with localhost which, I assume, was from one of the developers. 
The other one was just the base domain.

I changed this to just one line that would use the constant SITE_ROOT to define the siteRoot value.
Any other suggestions are welcome.
