### PR TITLE
Avoid noting most downloaded track and kart if null

### DIFF
--- a/include/Statistic.class.php
+++ b/include/Statistic.class.php
@@ -348,12 +348,12 @@ class Statistic
      * Return the most downloaded addon of a given type
      *
      * @param int $addon_type the type of addon
-     * @param string $file_type
+     * @param int $file_type
      *
      * @return null|string the name of the addon or null on empty selection
      * @throws StatisticException
      */
-    public static function mostDownloadedAddon($addon_type, $file_type = 'addon')
+    public static function mostDownloadedAddon($addon_type, $file_type = File::ADDON)
     {
         if (!Addon::isAllowedType($addon_type))
         {

--- a/index.php
+++ b/index.php
@@ -63,11 +63,20 @@ $news_messages = News::getWebVisible();
 // Note most downloaded track and kart
 $pop_kart = Statistic::mostDownloadedAddon(Addon::KART);
 $pop_track = Statistic::mostDownloadedAddon(Addon::TRACK);
-array_unshift(
-    $news_messages,
-    sprintf(_h('The most downloaded kart is %s.'), $pop_kart),
-    sprintf(_h('The most downloaded track is %s.'), $pop_track)
-);
+if ($pop_track !== null)
+{
+    array_unshift(
+        $news_messages,
+        sprintf(_h('The most downloaded track is %s.'), $pop_track)
+    );
+}
+if ($pop_kart !== null)
+{
+    array_unshift(
+        $news_messages,
+        sprintf(_h('The most downloaded kart is %s.'), $pop_kart)
+    );
+}
 
 $tpl->assign('news_messages', $news_messages);
 echo $tpl;


### PR DESCRIPTION
`Statistic::mostDownloadedAddon()` called in index.php can return `null`. To avoid messages like "The most downloaded kart is .", check that each of the most downloaded kart and track is not `null` before adding the respective message.