### PR TITLE
Allow player validation before joining some official server

### DIFF
--- a/api/user.php
+++ b/api/user.php
@@ -623,7 +623,34 @@ try
                 $output->endElement();
             }
             break;
+        case 'validate-player':
+            try
+            {
+                $userid = isset($_POST['userid']) ? (int)$_POST['userid'] : 0;
+                $token = isset($_POST['token']) ? $_POST['token'] : "";
+                $session = ClientSession::get($token, $userid);
+                $id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
 
+                $permission = AccessControl::getPermissions($session->getUser()->getRole());
+                $result = ClientSession::getSessionIDAndNameForValidation($permission, $id);
+                $output->startElement('validate-player');
+                    $output->writeAttribute('success', 'yes');
+                    $output->writeAttribute('info', '');
+                    $output->writeAttribute('token', $result['cid']);
+                    $output->writeAttribute('username', $result['username']);
+                $output->endElement();
+            }
+            catch(Exception $e)
+            {
+                $output->startElement('validate-player');
+                    $output->writeAttribute('success', 'no');
+                    $output->writeAttribute(
+                        'info',
+                        h($e->getMessage())
+                    );
+                $output->endElement();
+            }
+            break;
         default:
             $output->addErrorElement('request', 'Invalid action. Action = ' . h($_POST['action']));
             break;


### PR DESCRIPTION
See https://github.com/supertuxkart/stk-code/commit/54d608938ad2c7d037986c441fe3b65f8db0a967

Bascially player encrypt the connection message (with online player and other stuff) with his online token with uid visible, then the official server (and only official server can do this) will get the token of user from its uid, than decrypt and compare the username, if both succeed then player is validated.

Encryption in stk is xxtea from https://github.com/xxtea/xxtea-c

No one can spoof user id or player name with this way unless you know the token.

Auria / hiker / leyyin good way?