### PR TITLE
Use online.stk for xml files

### DIFF
--- a/include/xmlWrite.php
+++ b/include/xmlWrite.php
@@ -477,12 +477,16 @@ function generateAssetXML()
 
 function writeNewsXML()
 {
-    return FileSystem::filePutContents(NEWS_XML_PATH, generateNewsXML());
+    $newsxml = generateNewsXML();
+    FileSystem::filePutContents(NEWS_V2_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $newsxml));
+    return FileSystem::filePutContents(NEWS_XML_PATH, $newsxml);
 }
 
 function writeAssetXML()
 {
-    $count = FileSystem::filePutContents(ASSETS_XML_PATH, generateAssetXML());
+    $assetxml = generateAssetXML();
+    FileSystem::filePutContents(ASSETS_V2_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $assetxml));
+    $count = FileSystem::filePutContents(ASSETS_XML_PATH, $assetxml);
     //$count += File::write(ASSETS2_XML_PATH, generateAssetXML2());
     return $count;
 }

--- a/include/xmlWrite.php
+++ b/include/xmlWrite.php
@@ -478,15 +478,15 @@ function generateAssetXML()
 function writeNewsXML()
 {
     $newsxml = generateNewsXML();
-    FileSystem::filePutContents(NEWS_V2_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $newsxml));
-    return FileSystem::filePutContents(NEWS_XML_PATH, $newsxml);
+    FileSystem::filePutContents(NEWS_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $newsxml));
+    return FileSystem::filePutContents(OLD_NEWS_XML_PATH, $newsxml);
 }
 
 function writeAssetXML()
 {
     $assetxml = generateAssetXML();
-    FileSystem::filePutContents(ASSETS_V2_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $assetxml));
-    $count = FileSystem::filePutContents(ASSETS_XML_PATH, $assetxml);
+    FileSystem::filePutContents(ASSETS_XML_PATH, str_replace("http://addons.supertuxkart.net/dl/", "https://online.supertuxkart.net/dl/", $assetxml));
+    $count = FileSystem::filePutContents(OLD_ASSETS_XML_PATH, $assetxml);
     //$count += File::write(ASSETS2_XML_PATH, generateAssetXML2());
     return $count;
 }

--- a/install/config.EXAMPLE.php
+++ b/install/config.EXAMPLE.php
@@ -100,10 +100,10 @@ const ASSETS_PATH = ROOT_PATH . 'assets' . DS;
 const CACHE_PATH = ASSETS_PATH . 'cache' . DS; // cache for images/html/template
 const FONTS_PATH = ASSETS_PATH . 'fonts' . DS;
 
-const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
-const NEWS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'news_v2.xml';
-const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
-const ASSETS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'assets_v2.xml';
+const OLD_NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
+const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'online_news.xml';
+const OLD_ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
+const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'online_assets.xml';
 const ASSETS2_XML_PATH = UP_PATH . 'xml' . DS . 'assets2.xml';
 
 // Location urls

--- a/install/config.EXAMPLE.php
+++ b/install/config.EXAMPLE.php
@@ -101,7 +101,9 @@ const CACHE_PATH = ASSETS_PATH . 'cache' . DS; // cache for images/html/template
 const FONTS_PATH = ASSETS_PATH . 'fonts' . DS;
 
 const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
+const NEWS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'news_v2.xml';
 const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
+const ASSETS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'assets_v2.xml';
 const ASSETS2_XML_PATH = UP_PATH . 'xml' . DS . 'assets2.xml';
 
 // Location urls

--- a/phpstan/config.example_install_for_phpstan.php
+++ b/phpstan/config.example_install_for_phpstan.php
@@ -72,10 +72,10 @@ const ASSETS_PATH = ROOT_PATH . 'assets' . DS;
 const CACHE_PATH = ASSETS_PATH . 'cache' . DS; // cache for images/html/template
 const FONTS_PATH = ASSETS_PATH . 'fonts' . DS;
 
-const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
-const NEWS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'news_v2.xml';
-const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
-const ASSETS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'assets_v2.xml';
+const OLD_NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
+const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'online_news.xml';
+const OLD_ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
+const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'online_assets.xml';
 const ASSETS2_XML_PATH = UP_PATH . 'xml' . DS . 'assets2.xml';
 
 // Location urls

--- a/phpstan/config.example_install_for_phpstan.php
+++ b/phpstan/config.example_install_for_phpstan.php
@@ -73,7 +73,9 @@ const CACHE_PATH = ASSETS_PATH . 'cache' . DS; // cache for images/html/template
 const FONTS_PATH = ASSETS_PATH . 'fonts' . DS;
 
 const NEWS_XML_PATH = UP_PATH . 'xml' . DS . 'news.xml';
+const NEWS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'news_v2.xml';
 const ASSETS_XML_PATH = UP_PATH . 'xml' . DS . 'assets.xml';
+const ASSETS_V2_XML_PATH = UP_PATH . 'xml' . DS . 'assets_v2.xml';
 const ASSETS2_XML_PATH = UP_PATH . 'xml' . DS . 'assets2.xml';
 
 // Location urls


### PR DESCRIPTION
This PR creates another variant of news.xml and asset.xml for new clients capable of using the online.stk server. See https://github.com/supertuxkart/stk-code/issues/3842
- In `xmlWrite.php` it simply replaces all occurences of http:addons.stk with https:online.stk.
It's not the best method but there's no need to run `generate*XML()` twice only for changing the URL.
For custom servers using this PR it replaces nothing and creates the same xml files for new clients.
- In `config.EXAMPLE.php` and `config.example_install_for_phpstan.php` I added both new const.

If this gets merged the game client needs to use the new news_v2.xml. This can be done either by changing the hardcoded URL in stk-code or rewriting the URL via .htaccess for clients using online.stk

TODO:
- Should I add and return the bytecount for the new xml files like this comment for [assets2](https://github.com/MinIsMin/stk-addons/blob/4013da9c86d97b15802ff7f9225375a7eee783a2/include/xmlWrite.php#L490)?
- Is the name 'ASSETS_V2' ok or should I reuse `ASSETS2_XML_PATH` if it's not used for anything?