### PR TITLE
Update link in translations menu

### DIFF
--- a/tpl/default/menu-lang.tpl
+++ b/tpl/default/menu-lang.tpl
@@ -3,5 +3,5 @@
     {foreach $lang.items as $item}
         <li class="flag"><a href="{$item.url}" style="background-position: 0 {$item.y}px;"></a></li>
     {/foreach}
-    <li class="label"><a href="https://translations.launchpad.net/stk/stkaddons">{t}Translate STK-Addons{/t}</a></li>
+    <li class="label"><a href="https://www.transifex.com/supertuxkart/supertuxkart/">{t}Translate STK-Addons{/t}</a></li>
 </ul>


### PR DESCRIPTION
The link for "Translate STK-Addons" in the language selector dropdown still pointed to the old launchpad.net project