### PR TITLE
Add "Pending Approval" badge to addons

### DIFF
--- a/include/AddonViewer.class.php
+++ b/include/AddonViewer.class.php
@@ -312,6 +312,10 @@ class AddonViewer
     private static function badges($status)
     {
         $string = '';
+        if (!Addon::isApproved($status))
+        {
+            $string .= '<span class="badge f_pending">' . _h('Pending Approval') . '</span>';
+        }
         if (Addon::isFeatured($status))
         {
             $string .= '<span class="badge f_featured">' . _h('Featured') . '</span>';


### PR DESCRIPTION
Communicate to uploaders that their addon is awaiting approval by moderators. This also makes it clearer to moderators that an addon is not yet approved.

This commit does not include a CSS class for f_pending, so it defaults to badge white on grey.