### PR TITLE
Calculate pagination without including hidden addons

### DIFF
--- a/addons-menu.php
+++ b/addons-menu.php
@@ -35,7 +35,7 @@ try
 
     $pagination = PaginationTemplate::get()
         ->setItemsPerPage($limit)
-        ->setTotalItems(Addon::count($type))
+        ->setTotalItems(count(Addon::getAll($type)))
         ->setCurrentPage($current_page);
 
     $tpl = StkTemplate::get("addons/menu.tpl")


### PR DESCRIPTION
Solves https://github.com/supertuxkart/stk-addons/issues/142

This counts the addons and filters them the same way the list does.

Addon::count is no longer used in the codebase, so it is deleted.