### PR TITLE
Attempt to convert file text to UTF-8, fix empty addon licenses

### DIFF
--- a/include/FileSystem.class.php
+++ b/include/FileSystem.class.php
@@ -429,7 +429,7 @@ class FileSystem
             throw new FileSystemException("Trying to get file contents of a file that does not exist, file = '$filename'");
         }
 
-        $read_data = @file_get_contents($filename, $use_include_path);
+        $read_data = mb_convert_encoding(@file_get_contents($filename, $use_include_path), 'UTF-8');
         if ($read_data === false)
         {
             throw new FileSystemException(


### PR DESCRIPTION
Solves https://github.com/supertuxkart/stk-addons/issues/74. The empty license text was caused by `h()` in `include/functions.php` expecting text encoded as UTF-8, while the Mystery Island license file appears to be ISO-8859 encoded text, causing it to fail.

This code uses mb_convert_encoding() to guess and then convert file text to UTF-8.

Unfortunately the existing empty licenses will need to be added into the database manually, but there are probably very few of these.