### PR TITLE
Reject empty or non-UTF-8 license files

### DIFF
--- a/include/Upload.class.php
+++ b/include/Upload.class.php
@@ -409,8 +409,17 @@ class Upload
         {
             throw new UploadException(_h("The archive does not contain any addon information"));
         }
-        $this->properties['xml_attributes']['license'] =
-            h(FileSystem::fileGetContents($this->properties['license_file'], false));
+
+        $license_text = FileSystem::fileGetContents($this->properties['license_file'], false);
+        if ($license_text == "")
+        {
+            throw new UploadException(_h("The license file is empty"));
+        }
+        if (!mb_detect_encoding($license_text, 'UTF-8', true))
+        {
+            throw new UploadException(_h("The license file was not saved with UTF-8 text encoding. Select the UTF-8 option when saving the license file"));
+        }
+        $this->properties['xml_attributes']['license'] = h($license_text);
 
         // new revision
         $addon = null;


### PR DESCRIPTION
Solves https://github.com/supertuxkart/stk-addons/issues/134
Solves https://github.com/supertuxkart/stk-addons/issues/74. The empty license text was caused by h() in include/functions.php expecting text encoded as UTF-8, while the Mystery Island license file appears to be ISO-8859 encoded text, causing it to fail.

This code uses mb_detect_encoding() to try and detect and reject improperly encoded license files.

Unfortunately the existing empty licenses will need to be added into the database manually, but there are probably very few of these.