### PR TITLE
Ensure addon type is present in URL. Fixes #108.

### DIFF
--- a/assets/js/addon.js
+++ b/assets/js/addon.js
@@ -35,6 +35,10 @@
         onFormSubmit(form_identifier, callback_success, $addon_body, json_url, {}, "POST");
     }
 
+    if(window.location.href.indexOf("type=")===-1){
+        window.history.pushState({}, "", window.location.href + "&type=" + addon_type);
+    } // add addon type to current url if absent
+
     registerPagination($addon_menu, "addons-menu.php");
 
     $('.multiselect').multiselect({});


### PR DESCRIPTION
If absent, append the addon's type to the window's current URL using javascript without refreshing the page. This fixes the missing 'type' parameter when needed by the registerPagination function as occurs in issue #108.

Note that this is currently a fallback for [non-naturally occurring] cases which #178 fails to address.