### PR TITLE
Fix bug status filter treating all bugs as closed.

### DIFF
--- a/include/Bug.class.php
+++ b/include/Bug.class.php
@@ -453,11 +453,11 @@ class Bug extends Base
                 break;
 
             case "open":
-                $query .= " AND `close_id` is NULL";
+                $query .= " AND `close_id` = 0";
                 break;
 
             case "closed":
-                $query .= " AND `close_id` is NOT NULL";
+                $query .= " AND `close_id` <> 0";
                 break;
 
             default:


### PR DESCRIPTION
The default value for a bug's close_id in the database schema is 0, not null. The current bug status filter checks its nullity, which makes it consider all bugs closed, as none of their `close-id`'s are null. This PR fixes it.