### PR TITLE
Eliminate typeless links from the bugs manager.

### DIFF
--- a/bugs/view.php
+++ b/bugs/view.php
@@ -47,6 +47,7 @@ $tpl_data = [
     "user_id"      => $bug->getUserId(),
     "user_name"    => h($bug->getUserName()),
     "addon"        => $bug->getAddonId(),
+    "addon_type"   => $bug->getAddonType(),
     "date_report"  => $bug->getDateReport(),
     "date_edit"    => $bug->getDateEdit(),
 

--- a/include/Bug.class.php
+++ b/include/Bug.class.php
@@ -64,6 +64,12 @@ class Bug extends Base
     private $addon_id;
 
     /**
+     * The type of the addon
+     * @var string
+     */
+    private $addon_type;
+
+    /**
      * The user who closed the bug report
      * @var int
      */
@@ -162,6 +168,7 @@ class Bug extends Base
         $this->user_id = $bug_data["user_id"];
         $this->user_username = $bug_data["user_username"];
         $this->addon_id = $bug_data["addon_id"];
+        $this->addon_type = Addon::typeToString(Addon::getTypeByID($this->addon_id));
         $this->close_id = $bug_data["close_id"];
         $this->close_username = $bug_data["close_username"];
         $this->close_reason = $bug_data["close_reason"];
@@ -209,6 +216,14 @@ class Bug extends Base
     public function getAddonId()
     {
         return $this->addon_id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAddonType()
+    {
+        return $this->addon_type;
     }
 
     /**
@@ -340,7 +355,11 @@ class Bug extends Base
     public static function getAll($limit = -1, $current_page = 1)
     {
         return static::getAllFromTable(
-            "SELECT * FROM `{DB_VERSION}_bugs` ORDER BY `date_edit` DESC, `id` ASC",
+            "SELECT `bugs`.*, `addon_types`.`name_plural` AS `addon_type`
+            FROM `{DB_VERSION}_bugs` AS `bugs`
+            JOIN `{DB_VERSION}_addons` AS `addons` ON `bugs`.`addon_id` = `addons`.`id`
+            JOIN `{DB_VERSION}_addon_types` AS `addon_types` ON `addons`.`type` = `addon_types`.`type`
+            ORDER BY `bugs`.`date_edit` DESC, `bugs`.`id` ASC",
             $limit,
             $current_page
         );
@@ -435,16 +454,20 @@ class Bug extends Base
             throw new BugException(_h("The search term is empty"));
         }
 
-        $query = "SELECT id, addon_id, title, date_edit, date_close, close_id, close_reason FROM `{DB_VERSION}_bugs`";
+        $query = "SELECT `bugs`.*, `addon_types`.`name_plural` AS `addon_type`
+            FROM `{DB_VERSION}_bugs` AS `bugs`
+            JOIN `{DB_VERSION}_addons` AS `addons` ON `bugs`.`addon_id` = `addons`.`id`
+            JOIN `{DB_VERSION}_addon_types` AS `addon_types` ON `addons`.`type` = `addon_types`.`type`";
 
         // search in description
         if ($search_description)
         {
-            $query .= " WHERE (`addon_id` LIKE :search_term OR `title` LIKE :search_term OR `description` LIKE :search_term)";
+            $query .= " WHERE (`bugs`.`addon_id` LIKE :search_term OR `bugs`.`title` LIKE :search_term
+                OR `bugs`.`description` LIKE :search_term)";
         }
         else
         {
-            $query .= " WHERE (`addon_id` LIKE :search_term OR `title` LIKE :search_term)";
+            $query .= " WHERE (`bugs`.`addon_id` LIKE :search_term OR `bugs`.`title` LIKE :search_term)";
         }
 
         switch ($status)

--- a/tpl/default/bugs/all.tpl
+++ b/tpl/default/bugs/all.tpl
@@ -17,7 +17,7 @@
         {foreach $bugs.items as $item}
             <tr data-id="{$item.id}">
                 <th class="bugs"><a href="{$smarty.const.BUGS_LOCATION}?bug_id={$item.id}">{$item.id}</a></th>
-                <th><a href="{$root_location}addons.php?name={$item.addon_id}">{$item.addon_id}</a></th>
+                <th><a href="{$root_location}addons.php?type={$item.addon_type}&name={$item.addon_id}">{$item.addon_id}</a></th>
                 <th class="bugs"><a href="{$smarty.const.BUGS_LOCATION}?bug_id={$item.id}">{$item.title|truncate:42}</a></th>
                 <th>
                     {if $item.close_id}

--- a/tpl/default/bugs/view.tpl
+++ b/tpl/default/bugs/view.tpl
@@ -86,7 +86,7 @@
     </tr>
     <tr>
         <td class="col-md-2">{t}Addon{/t}:</td>
-        <td class="col-md-10"><a href="{$root_location}addons.php?name={$bug.addon}">{$bug.addon}</a></td>
+        <td class="col-md-10"><a href="{$root_location}addons.php?type={$bug.addon_type}&name={$bug.addon}">{$bug.addon}</a></td>
     </tr>
     <tr>
         <td class="col-md-2">{t}Date edit{/t}:</td>


### PR DESCRIPTION
Avoids naturally coming across the case in #108 and #175 from the bug tracker or without a manually crafted link.
Last PR for today, I promise.