### PR TITLE
Allow account recovery using only email address.

### DIFF
--- a/api/user.php
+++ b/api/user.php
@@ -457,12 +457,11 @@ try
             break;
 
         case 'recover':
-            $username = isset($_POST['username']) ? utf8_encode($_POST['username']) : "";
             $email = isset($_POST['email']) ? utf8_encode($_POST['email']) : "";
 
             try
             {
-                User::recover($username, $email);
+                User::recover($email);
 
                 $output->startElement('recover');
                     $output->writeAttribute('success', 'yes');

--- a/include/User.class.php
+++ b/include/User.class.php
@@ -620,6 +620,28 @@ final class User extends Base implements IAsXML
         return new User($data);
     }
 
+	/**
+     * Get a user instance by the email address
+     *
+     * @param string $email
+     *
+     * @return User
+     * @throws UserException
+     */
+    public static function getFromEmail($email)
+    {
+        $data = static::getFromField(
+            static::getSQLAll(),
+            "U.email",
+            $email,
+            DBConnection::PARAM_STR,
+            _h("Email does not exist"),
+            ":email"
+        );
+
+        return new User($data);
+    }
+
     /**
      * Filter an array of users of the template menu view
      *
@@ -1274,15 +1296,24 @@ final class User extends Base implements IAsXML
      *
      * @throws UserException
      */
-    public static function recover($username, $email)
+    public static function recover($email)
     {
         // validate
-        static::validateUserName($username);
         static::validateEmail($email);
 
-        $user_id = static::validateUsernameEmail($username, $email);
-        $verification_code = Verification::generate($user_id);
+        $user_id; $username;
+        try
+        {
+            $user = User::getFromEmail($email);
+            $user_id = $user->id;
+            $username = $user->username;
+        }
+        catch (UserException $e)
+        {
+            return; // silently fail
+        }
 
+        $verification_code = Verification::generate($user_id);
         try
         {
             // Send verification email
@@ -1298,7 +1329,7 @@ final class User extends Base implements IAsXML
             }
             catch (StkMailException $e)
             {
-                StkLog::newEvent('Password reset email for "' . $username . '" could not be sent.', LogLevel::ERROR);
+                StkLog::newEvent('Password reset email for "' . $email . '" could not be sent.', LogLevel::ERROR);
                 throw new UserException(
                     $e->getMessage() . ' ' . _h('Please contact a website administrator.'),
                     ErrorType::USER_SENDING_RECOVER_EMAIL
@@ -1308,7 +1339,7 @@ final class User extends Base implements IAsXML
         catch (DBException $e)
         {
             throw new UserException(
-                exception_message_db(_('validate your username and email address for password reset')),
+                exception_message_db(_('validate your email address for password reset')),
                 ErrorType::USER_SENDING_RECOVER_EMAIL
             );
         }

--- a/password-reset.php
+++ b/password-reset.php
@@ -63,8 +63,8 @@ switch ($_GET['action'])
                 throw new UserException(_h("The reCAPTCHA wasn't entered correctly. Go back and try it again."));
             }
 
-            User::recover($_POST['user'], $_POST['mail']);
-            $tpl->assign("success", _h("Password reset link sent. Please reset your password using the link emailed to you."));
+            User::recover($_POST['mail']);
+            $tpl->assign("success", _h("If an account exists with your email address, a password reset link has been sent. Please reset your password using the link emailed to you."));
         }
         catch(UserException $e)
         {

--- a/tpl/default/password-reset.tpl
+++ b/tpl/default/password-reset.tpl
@@ -5,13 +5,7 @@
     {if $pass_reset.reset_form.display == true}
         <form id="reset_pw" action="?action=reset" class="form-horizontal" method="POST">
             <div class="form-group col-md-12">
-                {t}In order to reset your password, please enter your username and your email address. A password reset link will be emailed to you. Your old password will become inactive until your password is reset.{/t}
-            </div>
-            <div class="form-group">
-                <label for="reg_user" class="col-md-2">{t}Username:{/t}</label>
-                <div class="col-md-4">
-                    <input type="text" name="user" class="form-control" id="reg_user">
-                </div>
+                {t}In order to reset your password, please enter your account's email address. A password reset link will be emailed to you.{/t}
             </div>
             <div class="form-group">
                 <label for="reg_email" class="col-md-2">{t}Email Address:{/t}</label>


### PR DESCRIPTION
Also, maintainers, please note that the ``User::validateUsernameEmail`` function is no longer used in the code after this commit, in case you want to remove it.
Fixes: https://github.com/supertuxkart/stk-code/issues/5645, #89.